### PR TITLE
Removing Node 14 from supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ## System Requirements
 
 - [git][git] v2.13 or greater
-- [NodeJS][node] `14 || 16 || 18`
+- [NodeJS][node] `16 || 18`
 - [npm][npm] v8 or greater
 
 All of these must be available in your `PATH`. To verify things are set up


### PR DESCRIPTION
Installation issues have been reported with Node 14. No issues with 16+