### PR TITLE
Fix final README typos

### DIFF
--- a/final/01-routing/README.md
+++ b/final/01-routing/README.md
@@ -18,7 +18,7 @@ routing. There are three options for routing in a Remix app:
 When you place a file in `app/routes` Remix creates a route for that file. You
 can
 [read about the filename convention here](https://remix.run/docs/en/v1/api/conventions#file-name-conventions).
-The most important think for you to know right now is that the file should have
+The most important thing for you to know right now is that the file should have
 a component as the `default` `export` which will be rendered for the part of the
 UI the file represents:
 

--- a/final/02-data-loading.extra-01-ts/README.md
+++ b/final/02-data-loading.extra-01-ts/README.md
@@ -102,7 +102,7 @@ Put that in your loader and then get that from the loader to the component using
 
 ## 🗃 Files
 
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ## 💯 Extra Credit
 
@@ -143,7 +143,7 @@ future).
 
 **Files**:
 
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ### 2. Switch to prisma for data
 
@@ -162,7 +162,7 @@ We'll be adding more functions to that module soon.
 **Files**:
 
 - `app/models/post.server.ts`
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ### 3. Optimize data loading
 
@@ -187,7 +187,7 @@ post listing page.
 **Files**:
 
 - `app/models/post.server.ts`
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ## 🦉 Elaboration and Feedback
 

--- a/final/02-data-loading.extra-02-prisma/README.md
+++ b/final/02-data-loading.extra-02-prisma/README.md
@@ -102,7 +102,7 @@ Put that in your loader and then get that from the loader to the component using
 
 ## 🗃 Files
 
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ## 💯 Extra Credit
 
@@ -143,7 +143,7 @@ future).
 
 **Files**:
 
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ### 2. Switch to prisma for data
 
@@ -162,7 +162,7 @@ We'll be adding more functions to that module soon.
 **Files**:
 
 - `app/models/post.server.ts`
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ### 3. Optimize data loading
 
@@ -187,7 +187,7 @@ post listing page.
 **Files**:
 
 - `app/models/post.server.ts`
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ## 🦉 Elaboration and Feedback
 

--- a/final/02-data-loading.extra-03-optimize/README.md
+++ b/final/02-data-loading.extra-03-optimize/README.md
@@ -102,7 +102,7 @@ Put that in your loader and then get that from the loader to the component using
 
 ## 🗃 Files
 
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ## 💯 Extra Credit
 
@@ -143,7 +143,7 @@ future).
 
 **Files**:
 
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ### 2. Switch to prisma for data
 
@@ -162,7 +162,7 @@ We'll be adding more functions to that module soon.
 **Files**:
 
 - `app/models/post.server.ts`
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ### 3. Optimize data loading
 
@@ -187,7 +187,7 @@ post listing page.
 **Files**:
 
 - `app/models/post.server.ts`
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ## 🦉 Elaboration and Feedback
 

--- a/final/02-data-loading/README.md
+++ b/final/02-data-loading/README.md
@@ -102,7 +102,7 @@ Put that in your loader and then get that from the loader to the component using
 
 ## 🗃 Files
 
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ## 💯 Extra Credit
 
@@ -143,7 +143,7 @@ future).
 
 **Files**:
 
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ### 2. Switch to prisma for data
 
@@ -162,7 +162,7 @@ We'll be adding more functions to that module soon.
 **Files**:
 
 - `app/models/post.server.ts`
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ### 3. Optimize data loading
 
@@ -187,7 +187,7 @@ post listing page.
 **Files**:
 
 - `app/models/post.server.ts`
-- `app/routs/posts/index.tsx`
+- `app/routes/posts/index.tsx`
 
 ## 🦉 Elaboration and Feedback
 

--- a/final/08-errors.extra-01-catch-boundaries/README.md
+++ b/final/08-errors.extra-01-catch-boundaries/README.md
@@ -95,7 +95,7 @@ export default function HiddenParentRoute() {
 ```
 
 So, if we want to add an error boundary to handle all unhandled errors under
-`/posts`, we'll need to create a `/app/routes/posts/tsx` file with that in it
+`/posts`, we'll need to create a `/app/routes/posts.tsx` file with that in it
 (to get the same functionality) and then we can add the `ErrorBoundary`.
 
 ## 🗃 Files

--- a/final/08-errors/README.md
+++ b/final/08-errors/README.md
@@ -95,7 +95,7 @@ export default function HiddenParentRoute() {
 ```
 
 So, if we want to add an error boundary to handle all unhandled errors under
-`/posts`, we'll need to create a `/app/routes/posts/tsx` file with that in it
+`/posts`, we'll need to create a `/app/routes/posts.tsx` file with that in it
 (to get the same functionality) and then we can add the `ErrorBoundary`.
 
 ## 🗃 Files

--- a/final/10-admin-user.extra-01-ui/README.md
+++ b/final/10-admin-user.extra-01-ui/README.md
@@ -1,4 +1,4 @@
-# 08. Error handling
+# 10. Admin user
 
 ## 📝 Notes
 

--- a/final/10-admin-user/README.md
+++ b/final/10-admin-user/README.md
@@ -1,4 +1,4 @@
-# 08. Error handling
+# 10. Admin user
 
 ## 📝 Notes
 


### PR DESCRIPTION
Looking through final READMEs, found a typo. Has been fixed in exercise file. 

PR to apply all previous typo fixes (https://github.com/FrontendMasters/remix-fundamentals/pull/3, https://github.com/FrontendMasters/remix-fundamentals/pull/5, https://github.com/FrontendMasters/remix-fundamentals/pull/6, https://github.com/FrontendMasters/remix-fundamentals/pull/7) in exercise files to final. 

