### PR TITLE
Exercise 01 README: small typo fix

### DIFF
--- a/exercise/01-routing/README.md
+++ b/exercise/01-routing/README.md
@@ -45,7 +45,7 @@ behavior and interacting directly with the browser's `history` API. To do this,
 we'll be using the `<Link />` component and the `to` prop:
 
 ```tsx
-<a href="/puppies">Full-page reload happines</a>
+<a href="/puppies">Full-page reload happiness</a>
 <Link to="/puppies">Client-side navigation happiness</Link>
 ```
 


### PR DESCRIPTION
Hey, I just wanted to help out by fixing this small typo I found in the readme, loving how the course is structured so far! I hope this is alright to do!

Changes `happines` to `happiness`