### PR TITLE
Fix loader function in exercise 10 README

### DIFF
--- a/exercise/10-admin-user/README.md
+++ b/exercise/10-admin-user/README.md
@@ -66,7 +66,7 @@ async function requireUserPermission(request: Request, permission: string) {
 }
 
 export async function loader({ request }: LoaderArgs) {
-  await requireUserPermission("emails.write");
+  await requireUserPermission(request, "emails.write");
   return json({});
 }
 ```


### PR DESCRIPTION
The function `requireUserPermission` takes the request as first argument. However, it was not passed in the loader function.